### PR TITLE
Support running without Docker and update the clearDB endpoint URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       - "${PORT}:8080"
     environment:
       - NODE_ENV=${MODE}
+      - IS_DOCKER=true
     env_file:
       - .env
     volumes:

--- a/server.js
+++ b/server.js
@@ -69,7 +69,7 @@ app.use(express.static(path.join(__dirname, "views")));
 
 // Create an axios instance for Upgrade API requests
 const upgradeApiClient = axios.create({
-    baseURL: UPGRADE_HOST_URL.includes("localhost")
+    baseURL: process.env.IS_DOCKER && UPGRADE_HOST_URL.includes("localhost")
         ? UPGRADE_HOST_URL.replace("localhost", "host.docker.internal")
         : UPGRADE_HOST_URL,
     headers: {
@@ -438,7 +438,7 @@ app.post("/api/v1/upgrade/metric/save", googleAuth, upgradeAuth, asyncHandler(as
 // Clear the database
 app.delete("/api/v1/upgrade/clearDB", googleAuth, upgradeAuth, asyncHandler(async (req, res) => {
     try {
-        const response = await upgradeApiClient.delete("/api/clearDB", {
+        const response = await upgradeApiClient.delete("/api/v5/clearDB", {
             headers: { "Authorization": `Bearer ${req.upgradeToken}` }
         });
         res.status(response.status).json(response.data);


### PR DESCRIPTION
This change fixes the `getaddrinfo ENOTFOUND host.docker.internal` error when running the app with `npm start` (without Docker). It also updates the non-existent `/api/clearDB` endpoint to `/api/v5/clearDB` (since there is currently a bug with `/api/v6/clearDB`).